### PR TITLE
Add light mode toggle

### DIFF
--- a/src/components/ThemeToggle.js
+++ b/src/components/ThemeToggle.js
@@ -1,0 +1,14 @@
+import React, { useContext } from "react";
+import { ThemeContext } from "../context/ThemeContext";
+
+const ThemeToggle = () => {
+  const { theme, toggleTheme } = useContext(ThemeContext);
+
+  return (
+    <button onClick={toggleTheme}>
+      {theme === "dark" ? "☀️ Light Mode" : "🌙 Dark Mode"}
+    </button>
+  );
+};
+
+export default ThemeToggle;

--- a/src/components/header.js
+++ b/src/components/header.js
@@ -4,6 +4,8 @@ import { auth } from "../utils/firebase";
 import { useLocation, useNavigate } from "react-router-dom";
 import { useSelector, useDispatch } from "react-redux";
 import { removeUser } from "../utils/userSlice";
+import ThemeToggle from "./ThemeToggle";
+
 
 const Header = () => {
   const [dropdownOpen, setDropdownOpen] = useState(false);
@@ -215,6 +217,7 @@ const Header = () => {
 
       {/* Profile Section */}
       <div className="flex items-center space-x-2 sm:space-x-4 z-10">
+        <ThemeToggle />
         {user ? (
           <div className="relative" ref={dropdownRef}>
             {/* Responsive Profile Icon */}

--- a/src/context/ThemeContext.js
+++ b/src/context/ThemeContext.js
@@ -1,0 +1,28 @@
+// File: src/context/ThemeContext.js
+import React, { createContext, useState, useEffect } from "react";
+
+export const ThemeContext = createContext();
+
+export const ThemeProvider = ({ children }) => {
+  const [theme, setTheme] = useState("dark");
+
+  useEffect(() => {
+    const savedTheme = localStorage.getItem("theme");
+    if (savedTheme) setTheme(savedTheme);
+  }, []);
+
+  useEffect(() => {
+    localStorage.setItem("theme", theme);
+    document.documentElement.className = theme;
+  }, [theme]);
+
+  const toggleTheme = () => {
+    setTheme(theme === "dark" ? "light" : "dark");
+  };
+
+  return (
+    <ThemeContext.Provider value={{ theme, toggleTheme }}>
+      {children}
+    </ThemeContext.Provider>
+  );
+};

--- a/src/index.css
+++ b/src/index.css
@@ -15,6 +15,21 @@ body {
   overflow-x: hidden;
   min-height: 100vh;
 }
+:root {
+  --bg-color: #ffffff;
+  --text-color: #000000;
+}
+
+.dark {
+  --bg-color: #121212;
+  --text-color: #ffffff;
+}
+
+body {
+  background-color: var(--bg-color);
+  color: var(--text-color);
+  transition: background-color 0.3s, color 0.3s;
+}
 
 /* Override all font families to use JetBrains Mono */
 * {

--- a/src/index.js
+++ b/src/index.js
@@ -3,6 +3,8 @@ import ReactDOM from 'react-dom/client';
 import './index.css';
 import App from './App';
 import reportWebVitals from './reportWebVitals';
+import { ThemeProvider } from "./context/ThemeContext";
+
 
 // Global error suppression for third-party video player errors
 const originalConsoleError = console.error;
@@ -96,7 +98,9 @@ window.addEventListener('error', (event) => {
 const root = ReactDOM.createRoot(document.getElementById('root'));
 root.render(
   <React.StrictMode>
+    <ThemeProvider>
     <App />
+    </ThemeProvider>
   </React.StrictMode>
 );
 


### PR DESCRIPTION
Closes: #42 

### Hacktoberfest 2025 Contribution 🎉

This PR adds **light/dark mode functionality** to the NEXUS app, enabling users to toggle between themes and persist their choice.

### What was done
- Added `ThemeContext` to manage global **light/dark theme** state.  
- Added a **toggle button** in the header for switching themes.  
- Saved selected theme in **localStorage** for persistence across page reloads.  
- Updated CSS to support **light mode**, complementing existing dark mode.  
- Wrapped the `<App />` component with `ThemeProvider` in `index.js`.

### How to test
1. Open the app — it should **default to dark mode**.  
2. Click the **theme toggle button** → the app should switch to **light mode**.  
3. Reload the page → the selected theme should **persist**.  
4. Toggle back to dark mode → verify persistence again.  

### Notes
- Firebase-related features (auth, database) are **not affected**.  
- This is a **front-end only feature**, safe for independent testing.  
- This contribution counts for **Hacktoberfest 2025** 🎃.
